### PR TITLE
feat: Check internal links

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,6 +46,7 @@ Imports:
     stringr,
     textutils,
     tibble,
+    urltools,
     usethis,
     whoami,
     xml2,

--- a/R/ro_check_urls.R
+++ b/R/ro_check_urls.R
@@ -29,11 +29,25 @@ ro_check_urls <- function(path = NULL) {
     xml2::xml_find_all("//link") %>%
     xml2::xml_attr("destination")
 
-  urls <- urls[grepl("http", urls)]
+  non_remote_urls <- urls[!grepl("^http", urls)]
+  bad_urls <- non_remote_urls[!grepl("^/", non_remote_urls)]
+  if ((length(bad_urls) > 0)) {
+    usethis::ui_todo(glue::glue("Wrong URLs, slash missing: {glue::glue_collapse(bad_urls, sep = ', ')}."))
+  }
+
+  urls <- urls[!(urls %in% bad_urls)]
+
+  ok_url <- function(url) {
+    if (!grepl("^http", url)) {
+      url <- sprintf("https://ropensci.org%s", url)
+    }
+
+    crul::ok(url, verb = "get")
+  }
 
   df <- tibble::tibble(
     url = urls,
-    ok = purrr::map_lgl(urls, crul::ok, verb = "get")
+    ok = purrr::map_lgl(urls, ok_url)
   )
   notok <- df$url[!df$ok]
 

--- a/R/ro_check_urls.R
+++ b/R/ro_check_urls.R
@@ -29,6 +29,14 @@ ro_check_urls <- function(path = NULL) {
     xml2::xml_find_all("//link") %>%
     xml2::xml_attr("destination")
 
+  full_urls <- urls[!is.na(urltools::domain(urls))]
+  localhost_urls <- full_urls[urltools::domain(full_urls) == "localhost"]
+
+  if ((length(localhost_urls) > 0)) {
+    usethis::ui_todo(glue::glue("Wrong URLs, remove localhost part to create a relative URL: {glue::glue_collapse(localhost_urls, sep = ', ')}."))
+  }
+
+  urls <- urls[!(urls %in% localhost_urls)]
   non_remote_urls <- urls[!grepl("^http", urls)]
   bad_urls <- non_remote_urls[!grepl("^/", non_remote_urls)]
   if ((length(bad_urls) > 0)) {

--- a/R/ro_check_urls.R
+++ b/R/ro_check_urls.R
@@ -36,7 +36,13 @@ ro_check_urls <- function(path = NULL) {
     usethis::ui_todo(glue::glue("Wrong URLs, remove localhost part to create a relative URL: {glue::glue_collapse(localhost_urls, sep = ', ')}."))
   }
 
-  urls <- urls[!(urls %in% localhost_urls)]
+  email_urls <- urls[grepl("@", urls)]
+  bad_email_urls <- email_urls[!grepl("mailto:", email_urls)]
+  if ((length(bad_email_urls) > 0)) {
+    usethis::ui_todo(glue::glue("Wrong email links, add 'mailto:' in front of the emails: {glue::glue_collapse(bad_email_urls, sep = ', ')}."))
+  }
+
+  urls <- urls[!(urls %in% c(localhost_urls, email_urls))]
   non_remote_urls <- urls[!grepl("^http", urls)]
   bad_urls <- non_remote_urls[!grepl("^/", non_remote_urls)]
   if ((length(bad_urls) > 0)) {

--- a/inst/examples/links.md
+++ b/inst/examples/links.md
@@ -32,3 +32,7 @@ Save this file under /content/blog/YEAR-MONTH-DAY-slug.md in the local copy of y
 [Broken local link](/4000004/)
 
 [Missing slash](blog)
+
+[Bad email link](maelle@ropensci.org)
+
+[Good email link](mailto:yabellini@ropensci.org)

--- a/inst/examples/links.md
+++ b/inst/examples/links.md
@@ -21,6 +21,8 @@ Save this file under /content/blog/YEAR-MONTH-DAY-slug.md in the local copy of y
 
 [Cool blog](/blog/)
 
+[bad](http://localhost:1313/blog)
+
 [http](http://masalmon.eu/)
 
 [Broken blog](https://masalmon.eu/40004)

--- a/inst/examples/links.md
+++ b/inst/examples/links.md
@@ -1,0 +1,32 @@
+---
+slug: "post-template"
+title: Wonderful title
+package_version: 0.1.0
+authors:
+  - Author Name
+date: 2019-06-04
+categories: blog
+topicid:
+tags:
+  - Software Peer Review
+  - R
+  - community
+# delete the line below
+# if you have no preferred image
+# for Twitter cards
+twitterImg: img/blog-images/2019-06-04-post-template/name-of-image.png
+---
+
+Save this file under /content/blog/YEAR-MONTH-DAY-slug.md in the local copy of your roweb2 fork.
+
+[Cool blog](/blog/)
+
+[http](http://masalmon.eu/)
+
+[Broken blog](https://masalmon.eu/40004)
+
+[Broken blog again](https://masalmon.eu/400040)
+
+[Broken local link](/4000004/)
+
+[Missing slash](blog)

--- a/tests/testthat/_snaps/ro_check_urls.md
+++ b/tests/testthat/_snaps/ro_check_urls.md
@@ -3,6 +3,7 @@
     Code
       ro_check_urls(path)
     Message <rlang_message>
+      * Wrong URLs, remove localhost part to create a relative URL: http://localhost:1313/blog.
       * Wrong URLs, slash missing: blog.
       * Possibly broken URLs: https://masalmon.eu/40004, https://masalmon.eu/400040, /4000004/.
       * Replace http with https for: http://masalmon.eu/.

--- a/tests/testthat/_snaps/ro_check_urls.md
+++ b/tests/testthat/_snaps/ro_check_urls.md
@@ -4,6 +4,7 @@
       ro_check_urls(path)
     Message <rlang_message>
       * Wrong URLs, remove localhost part to create a relative URL: http://localhost:1313/blog.
+      * Wrong email links, add 'mailto:' in front of the emails: maelle@ropensci.org.
       * Wrong URLs, slash missing: blog.
       * Possibly broken URLs: https://masalmon.eu/40004, https://masalmon.eu/400040, /4000004/.
       * Replace http with https for: http://masalmon.eu/.

--- a/tests/testthat/_snaps/ro_check_urls.md
+++ b/tests/testthat/_snaps/ro_check_urls.md
@@ -3,7 +3,8 @@
     Code
       ro_check_urls(path)
     Message <rlang_message>
-      * Possibly broken URLs: https://masalmon.eu/40004, https://masalmon.eu/400040.
+      * Wrong URLs, slash missing: blog.
+      * Possibly broken URLs: https://masalmon.eu/40004, https://masalmon.eu/400040, /4000004/.
       * Replace http with https for: http://masalmon.eu/.
 
 ---

--- a/tests/testthat/test-ro_check_urls.R
+++ b/tests/testthat/test-ro_check_urls.R
@@ -1,6 +1,6 @@
 test_that("ro_check_urls works", {
   path <- system.file(
-    file.path("examples", "bad-no-alt.md"),
+    file.path("examples", "links.md"),
     package = "roblog"
   )
   testthat::expect_snapshot(ro_check_urls(path))


### PR DESCRIPTION
Fix #59

@steffilazerte Open to your review when you are back. :grin: 

This adds:
- check that internal links start with a slash;
- check that internal links exist on ropensci.org.

So if a PR is adding two pages at once and adding an internal link to one of them in the other, that link might get flagged as broken. Does it sound rare enough?

If not I could make the function serve the site as it is in the PR and check the links from that "preview". 